### PR TITLE
Flow layout for Library

### DIFF
--- a/noteorganiser/flowlayout.py
+++ b/noteorganiser/flowlayout.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+"""PyQt4 port of the layouts/flowlayout example from Qt v4.x"""
+
+from PySide import QtCore, QtGui
+
+
+class Window(QtGui.QWidget):
+    def __init__(self):
+        super(Window, self).__init__()
+
+        flowLayout = FlowLayout()
+        flowLayout.addWidget(QtGui.QPushButton("Short"))
+        flowLayout.addWidget(QtGui.QPushButton("Longer"))
+        flowLayout.addWidget(QtGui.QPushButton("Different text"))
+        flowLayout.addWidget(QtGui.QPushButton("More text"))
+        flowLayout.addWidget(QtGui.QPushButton("Even longer button text"))
+        self.setLayout(flowLayout)
+
+        self.setWindowTitle("Flow Layout")
+
+
+class FlowLayout(QtGui.QLayout):
+    def __init__(self, parent=None, margin=0, spacing=-1):
+        super(FlowLayout, self).__init__(parent)
+
+        if parent is not None:
+            self.setMargin(margin)
+
+        self.setSpacing(spacing)
+
+        self.itemList = []
+
+    def __del__(self):
+        item = self.takeAt(0)
+        while item:
+            item = self.takeAt(0)
+
+    def addItem(self, item):
+        self.itemList.append(item)
+
+    def count(self):
+        return len(self.itemList)
+
+    def itemAt(self, index):
+        if index >= 0 and index < len(self.itemList):
+            return self.itemList[index]
+
+        return None
+
+    def takeAt(self, index):
+        if index >= 0 and index < len(self.itemList):
+            return self.itemList.pop(index)
+
+        return None
+
+    def expandingDirections(self):
+        return QtCore.Qt.Orientations(QtCore.Qt.Orientation(0))
+
+    def hasHeightForWidth(self):
+        return True
+
+    def heightForWidth(self, width):
+        height = self.doLayout(QtCore.QRect(0, 0, width, 0), True)
+        return height
+
+    def setGeometry(self, rect):
+        super(FlowLayout, self).setGeometry(rect)
+        self.doLayout(rect, False)
+
+    def sizeHint(self):
+        return self.minimumSize()
+
+    def minimumSize(self):
+        size = QtCore.QSize()
+
+        for item in self.itemList:
+            size = size.expandedTo(item.minimumSize())
+
+        size += QtCore.QSize(2 * self.contentsMargins().top(), 2 * self.contentsMargins().top())
+        return size
+
+    def doLayout(self, rect, testOnly):
+        x = rect.x()
+        y = rect.y()
+        lineHeight = 0
+
+        for item in self.itemList:
+            wid = item.widget()
+            spaceX = self.spacing()
+            spaceY = self.spacing()
+            #spaceX = self.spacing() + wid.style().layoutSpacing(QtGui.QSizePolicy.PushButton, QtGui.QSizePolicy.PushButton, QtCore.Qt.Horizontal)
+            #spaceY = self.spacing() + wid.style().layoutSpacing(QtGui.QSizePolicy.PushButton, QtGui.QSizePolicy.PushButton, QtCore.Qt.Vertical)
+            nextX = x + item.sizeHint().width() + spaceX
+            if nextX - spaceX > rect.right() and lineHeight > 0:
+                x = rect.x()
+                y = y + lineHeight + spaceY
+                nextX = x + item.sizeHint().width() + spaceX
+                lineHeight = 0
+
+            if not testOnly:
+                item.setGeometry(QtCore.QRect(QtCore.QPoint(x, y), item.sizeHint()))
+
+            x = nextX
+            lineHeight = max(lineHeight, item.sizeHint().height())
+
+        return y + lineHeight - rect.y()
+
+
+if __name__ == '__main__':
+
+    import sys
+
+    app = QtGui.QApplication(sys.argv)
+    mainWin = Window()
+    mainWin.show()
+    sys.exit(app.exec_())

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -17,6 +17,8 @@ from PySide import QtGui
 from PySide import QtCore
 from PySide import QtWebKit
 
+from .flowlayout import FlowLayout
+
 from subprocess import Popen
 
 # Local imports
@@ -693,30 +695,12 @@ class Shelves(CustomFrame):
         self.info.level = folder_path
         self.refresh()
 
-    def resizeEvent(self, event):
-        if event.oldSize().width() != -1:
-            self.refresh()
-
     def createLines(self):
         # Defining the icon size used
         self.size = 128
 
-        # Number of elements on each line
-        # This might fail for some cases
-        objectsPerLine = self.width() // (self.size*1.2)
-        if objectsPerLine == 0:
-            objectsPerLine = 1
-
-        if objectsPerLine == self.objectsPerLine:
-            return self.grid
-
-        if self.objectsPerLine == 0:
-            self.objectsPerLine = objectsPerLine
-
-        index_row, index_column = 0, 0
-
         # Create the lines array
-        grid = QtGui.QGridLayout()
+        grid = FlowLayout()
         for index, notebook in enumerate(self.info.notebooks):
             # distinguish between a notebook and a folder, stored as a tuple.
             # When encountering a folder, simply put a different image for the
@@ -732,13 +716,7 @@ class Shelves(CustomFrame):
             button.clicked.connect(self.notebookClicked)
             button.deleteNotebook.connect(self.removeNotebook)
             self.buttons.append(button)
-            grid.addWidget(button, index_column, index_row)
-
-            # Incrementing the index_object
-            index_row += 1
-            if index_row % objectsPerLine == 0:
-                index_row = 0
-                index_column += 1
+            grid.addWidget(button)
 
         for index, folder in enumerate(self.info.folders):
             button = PicButton(
@@ -750,11 +728,7 @@ class Shelves(CustomFrame):
             button.setMaximumSize(self.size, self.size)
             button.clicked.connect(self.folderClicked)
             self.buttons.append(button)
-            grid.addWidget(button, index_column, index_row)
-            index_row += 1
-            if index_row % objectsPerLine == 0:
-                index_row = 0
-                index_column += 1
+            grid.addWidget(button)
 
         self.grid = grid
         return grid


### PR DESCRIPTION
use FlowLayout instead of QGridLayout for the library. This automatically rearranges the items on resizing

this change fixes problems with the Window resizing:
- faster resizing in the `Library`
- no minimum width on other tabs, caused by the items in `Library`