### PR TITLE
check if the process-call to the external editor fails

### DIFF
--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -236,7 +236,18 @@ class Editing(CustomFrame):
         index = self.tabs.currentIndex()
         notebook = os.path.join(self.info.level, self.info.notebooks[index])
         # open the file in the external editor set by the user
-        Popen([self.info.externalEditor, notebook])
+        # if this fails, show a popup
+        try:
+            Popen([self.info.externalEditor, notebook])
+            self.log.info('external editor opened for notebook %s' % notebook)
+        except OSError as e:
+            self.log.error('Execution of external editor failed: %s' % e)
+            self.popup = QtGui.QMessageBox(self)
+            self.popup.setIcon(QtGui.QMessageBox.Critical)
+            self.popup.setWindowTitle('NoteOrganiser')
+            self.popup.setText("The external editor couldn't be opened.")
+            self.popup.setInformativeText("%s" % e)
+            ok = self.popup.exec_()
 
     def preview(self):
         """

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -245,9 +245,10 @@ class Editing(CustomFrame):
             self.popup = QtGui.QMessageBox(self)
             self.popup.setIcon(QtGui.QMessageBox.Critical)
             self.popup.setWindowTitle('NoteOrganiser')
-            self.popup.setText("The external editor couldn't be opened.")
-            self.popup.setInformativeText(
-                "%s\n\n commandline:\n %s" % (e, self.info.externalEditor))
+            self.popup.setText(
+                "The external editor '%s' couldn't be opened." % (
+                self.info.externalEditor))
+            self.popup.setInformativeText("%s" % e)
             self.popup.exec_()
 
     def preview(self):

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -247,7 +247,7 @@ class Editing(CustomFrame):
             self.popup.setWindowTitle('NoteOrganiser')
             self.popup.setText("The external editor couldn't be opened.")
             self.popup.setInformativeText("%s" % e)
-            ok = self.popup.exec_()
+            self.popup.exec_()
 
     def preview(self):
         """

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -246,7 +246,8 @@ class Editing(CustomFrame):
             self.popup.setIcon(QtGui.QMessageBox.Critical)
             self.popup.setWindowTitle('NoteOrganiser')
             self.popup.setText("The external editor couldn't be opened.")
-            self.popup.setInformativeText("%s" % e)
+            self.popup.setInformativeText(
+                "%s\n\n commandline:\n %s" % (e, self.info.externalEditor))
             self.popup.exec_()
 
     def preview(self):


### PR DESCRIPTION
when the user clicks on `edit (exterior editor)` and the call succeeds, just log the notebook. Else, log an error and open a popup to inform the user about the failure
