### PR TITLE
add a search field for the tag buttons in Preview

### DIFF
--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -466,6 +466,12 @@ class Preview(CustomFrame):
         dummy.setFixedWidth(200)
 
         vbox = QtGui.QVBoxLayout()
+
+        # search field for the buttons
+        self.searchField = QtGui.QLineEdit()
+        self.searchField.textChanged.connect(self.filterButtons)
+        vbox.addWidget(self.searchField)
+
         self.tagButtons = []
         if self.extracted_tags:
             for key, value in six.iteritems(self.extracted_tags):
@@ -673,6 +679,15 @@ class Preview(CustomFrame):
             else:
                 self.disableButton(button)
         self.setWebpage(url)
+
+    def filterButtons(self, filterText):
+        """
+        filter buttons by the text in the search field
+
+        gets called when the text in the search field changes
+        """
+        for _, button in self.tagButtons:
+            button.setVisible(button.text().startswith(filterText.strip()))
 
 
 class Shelves(CustomFrame):

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -462,8 +462,6 @@ class Preview(CustomFrame):
         # Need to create a dummy Widget, because QScrollArea can not accept a
         # layout, only a Widget
         dummy = QtGui.QWidget()
-        # Limit its width
-        dummy.setFixedWidth(200)
 
         vbox = QtGui.QVBoxLayout()
         # let size grow AND shrink
@@ -472,6 +470,7 @@ class Preview(CustomFrame):
         # search field for the buttons
         self.searchField = QtGui.QLineEdit()
         self.searchField.textChanged.connect(self.filterButtons)
+        self.searchField.setMaximumWidth(165)
         vbox.addWidget(self.searchField)
 
         self.tagButtons = []
@@ -488,6 +487,8 @@ class Preview(CustomFrame):
         # Adding everything to the scroll area
         dummy.setLayout(vbox)
         scrollArea.setWidget(dummy)
+        # Limit its width
+        dummy.setFixedWidth(200)
 
         self.layout().addWidget(scrollArea)
 

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -471,6 +471,7 @@ class Preview(CustomFrame):
         # search field for the buttons
         self.searchField = QtGui.QLineEdit()
         self.searchField.textChanged.connect(self.filterButtons)
+        self.searchField.returnPressed.connect(self.searchFieldReturn)
         self.searchField.setMaximumWidth(165)
         vbox.addWidget(self.searchField)
 
@@ -692,6 +693,16 @@ class Preview(CustomFrame):
         """
         for key, button in self.tagButtons:
             button.setVisible(fuzzySearch(filterText, key))
+
+    def searchFieldReturn(self):
+        """
+        return key was pressed in the searchField
+
+        hit the first visible tag button
+        """
+        button = [button for _, button in self.tagButtons
+                  if button.isVisible()][0]
+        button.click()
 
 
 class Shelves(CustomFrame):

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -472,6 +472,7 @@ class Preview(CustomFrame):
         self.searchField = QtGui.QLineEdit()
         self.searchField.textChanged.connect(self.filterButtons)
         self.searchField.returnPressed.connect(self.searchFieldReturn)
+        self.searchField.setPlaceholderText('filter tags')
         self.searchField.setMaximumWidth(165)
         vbox.addWidget(self.searchField)
 

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -19,6 +19,7 @@ from PySide import QtCore
 from PySide import QtWebKit
 
 from .flowlayout import FlowLayout
+from .utils import fuzzySearch
 
 from subprocess import Popen
 
@@ -690,7 +691,7 @@ class Preview(CustomFrame):
         gets called when the text in the search field changes
         """
         for key, button in self.tagButtons:
-            button.setVisible(key.startswith(filterText.strip().lower()))
+            button.setVisible(fuzzySearch(filterText, key))
 
 
 class Shelves(CustomFrame):

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -466,6 +466,8 @@ class Preview(CustomFrame):
         dummy.setFixedWidth(200)
 
         vbox = QtGui.QVBoxLayout()
+        # let size grow AND shrink
+        vbox.setSizeConstraint(QtGui.QLayout.SetMinAndMaxSize)
 
         # search field for the buttons
         self.searchField = QtGui.QLineEdit()
@@ -686,8 +688,8 @@ class Preview(CustomFrame):
 
         gets called when the text in the search field changes
         """
-        for _, button in self.tagButtons:
-            button.setVisible(button.text().startswith(filterText.strip()))
+        for key, button in self.tagButtons:
+            button.setVisible(key.startswith(filterText.strip()))
 
 
 class Shelves(CustomFrame):

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -29,7 +29,7 @@ import noteorganiser.text_processing as tp
 from .constants import EXTENSION
 from .configuration import search_folder_recursively
 from .syntax import ModifiedMarkdownHighlighter
-from .widgets import PicButton, VerticalScrollArea
+from .widgets import PicButton, VerticalScrollArea, LineEditWithClearButton
 
 
 class CustomFrame(QtGui.QFrame):
@@ -469,7 +469,7 @@ class Preview(CustomFrame):
         vbox.setSizeConstraint(QtGui.QLayout.SetMinAndMaxSize)
 
         # search field for the buttons
-        self.searchField = QtGui.QLineEdit()
+        self.searchField = LineEditWithClearButton()
         self.searchField.textChanged.connect(self.filterButtons)
         self.searchField.returnPressed.connect(self.searchFieldReturn)
         self.searchField.setPlaceholderText('filter tags')

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -690,7 +690,7 @@ class Preview(CustomFrame):
         gets called when the text in the search field changes
         """
         for key, button in self.tagButtons:
-            button.setVisible(key.startswith(filterText.strip()))
+            button.setVisible(key.startswith(filterText.strip().lower()))
 
 
 class Shelves(CustomFrame):

--- a/noteorganiser/tests/test_frames.py
+++ b/noteorganiser/tests/test_frames.py
@@ -330,7 +330,7 @@ def test_editing(qtbot, parent):
 
     # Check that zoom-in, zoom-out, reset size are implemented
     editor = editing.tabs.currentWidget()
-    
+
     # Fontsize should be bigger
     editing.zoomIn()
     assert editor.text.currentFont().pointSize() > editor.defaultFontSize
@@ -389,3 +389,26 @@ def test_preview(qtbot, parent):
 
     # Reload should work (how to test that it truly works?)
     preview.reload()
+
+    # check searchField
+    # isVisibleTo(preview) is needed because qtbot doesn't show the actual
+    # root-widget (here: preview)
+    # so we can check if the widget in question and any parent up to but
+    # excluding the given ancestor are not hidden themselves
+    # see documentation for Pyside.QtGui.QWidget.isVisibleTo(arg__1)
+    #
+    # all buttons should be visible
+    assert len([key for key, button in preview.tagButtons if
+               button.isVisibleTo(preview)]) == 6
+    # filter out all but one
+    qtbot.keyClicks(preview.searchField, 'b')
+    assert len([key for key, button in preview.tagButtons if
+               button.isVisibleTo(preview)]) == 1
+    # filter out all
+    qtbot.keyClicks(preview.searchField, 'bbbb')
+    assert len([key for key, button in preview.tagButtons if
+               button.isVisibleTo(preview)]) == 0
+    # show all again
+    preview.searchField.clear()
+    assert len([key for key, button in preview.tagButtons if
+               button.isVisibleTo(preview)]) == 6

--- a/noteorganiser/tests/test_frames.py
+++ b/noteorganiser/tests/test_frames.py
@@ -403,7 +403,7 @@ def test_preview(qtbot, parent):
     # filter out all but one
     qtbot.keyClicks(preview.searchField, 'b')
     assert len([key for key, button in preview.tagButtons if
-               button.isVisibleTo(preview)]) == 1
+               button.isVisibleTo(preview)]) == 2
     # filter out all
     qtbot.keyClicks(preview.searchField, 'bbbb')
     assert len([key for key, button in preview.tagButtons if

--- a/noteorganiser/tests/test_utils.py
+++ b/noteorganiser/tests/test_utils.py
@@ -5,7 +5,6 @@ import shutil
 import datetime
 from PySide import QtGui
 from PySide import QtCore
-import test
 
 #utils to test
 from ..utils import fuzzySearch

--- a/noteorganiser/tests/test_utils.py
+++ b/noteorganiser/tests/test_utils.py
@@ -1,0 +1,37 @@
+"""tests for utilities"""
+
+import os
+import shutil
+import datetime
+from PySide import QtGui
+from PySide import QtCore
+import test
+
+#utils to test
+from ..utils import fuzzySearch
+from .custom_fixtures import parent
+
+
+def test_fuzzySearch():
+    ### these should return True
+
+    #starts with the searchstring
+    assert fuzzySearch('g', 'git got gut')
+    #starts with the (longer) searchstring
+    assert fuzzySearch('git', 'git got gut')
+    #searchstring not at the start
+    assert fuzzySearch('got', 'git got gut')
+    #multiple substrings (separated by a space) found somewhere in the string
+    assert fuzzySearch('gi go', 'git got gut')
+    #empty string
+    assert fuzzySearch('', 'git got gut')
+    #strange whitespace
+    assert fuzzySearch('gi   go', 'git  got gut')
+    assert fuzzySearch('gi	go', 'git  got gut')
+
+    ### these should return False
+
+    #searchstring not found
+    assert not fuzzySearch('bot', 'git got gut')
+    #searchstring not found
+    assert not fuzzySearch('gran', 'this is a great neat thing')

--- a/noteorganiser/tests/test_widgets.py
+++ b/noteorganiser/tests/test_widgets.py
@@ -1,0 +1,23 @@
+"""tests for custom widgets"""
+from PySide import QtGui
+from PySide import QtCore
+
+#widgets to test
+from ..widgets import LineEditWithClearButton
+from .custom_fixtures import parent
+
+
+def test_LineEditWithClearButton(qtbot, parent):
+    lineEdit = LineEditWithClearButton()
+    qtbot.addWidget(lineEdit)
+
+    assert hasattr(lineEdit, 'clearButton')
+
+    assert not len(lineEdit.text())
+    assert not lineEdit.clearButton.isVisibleTo(lineEdit)
+    qtbot.keyClicks(lineEdit, 'titi')
+    assert len(lineEdit.text())
+    assert lineEdit.clearButton.isVisibleTo(lineEdit)
+    qtbot.mouseClick(lineEdit.clearButton, QtCore.Qt.LeftButton)
+    assert not len(lineEdit.text())
+    assert not lineEdit.clearButton.isVisibleTo(lineEdit)

--- a/noteorganiser/utils.py
+++ b/noteorganiser/utils.py
@@ -1,0 +1,24 @@
+"""custom utilities"""
+
+from __future__ import unicode_literals
+import re
+
+
+def fuzzySearch(searchInput, baseString):
+    """fuzzy comparison of the strings"""
+    #normalize strings
+    searchInput = re.sub(r'\s', r' ', searchInput.lower())
+    baseString = re.sub(r'\s', r' ', baseString.lower())
+
+    #normal substring comparison
+    if searchInput in baseString:
+        return True
+
+    # split searchInput and check them separately
+    if ' ' in searchInput:
+        if not [subString for subString in searchInput.split(' ') if not
+                fuzzySearch(subString, baseString)]:
+            return True
+
+    # no match found
+    return False

--- a/noteorganiser/widgets.py
+++ b/noteorganiser/widgets.py
@@ -105,3 +105,50 @@ class VerticalScrollArea(QtGui.QScrollArea):
                 self.widget().minimumSizeHint().width() +
                 self.verticalScrollBar().width())
         return QtGui.QScrollArea.eventFilter(self, item, event)
+
+
+class LineEditWithClearButton(QtGui.QLineEdit):
+    """a line edit widget that shows a clear button if there is text"""
+    buttonClicked = QtCore.Signal(bool)
+
+    def __init__(self, parent=None):
+        super(LineEditWithClearButton, self).__init__(parent)
+
+        self.clearButton = QtGui.QPushButton('x', self)
+        palette = QtGui.QPalette()
+        palette.setColor(QtGui.QPalette.ButtonText, QtCore.Qt.red)
+        self.clearButton.setPalette(palette)
+        self.clearButton.setStyleSheet('border: 0px;'
+                                       'padding: 0px;'
+                                       'padding-right: 3px;'
+                                       'font-weight: bold;')
+        self.clearButton.setCursor(QtCore.Qt.ArrowCursor)
+        self.clearButton.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.clearButton.setVisible(False)
+        self.clearButton.clicked.connect(self.clear)
+        self.textChanged.connect(self.showClearButton)
+
+        frameWidth = self.style().pixelMetric(
+            QtGui.QStyle.PM_DefaultFrameWidth)
+        buttonSize = self.clearButton.sizeHint()
+
+        self.setStyleSheet('QLineEdit {padding-right: %dpx; }' %
+                           (buttonSize.width() + frameWidth))
+        self.setMinimumSize(max(self.minimumSizeHint().width(),
+                            buttonSize.width() + frameWidth*2),
+                            max(self.minimumSizeHint().height(),
+                                buttonSize.height() + frameWidth*2))
+
+    def resizeEvent(self, event):
+        """move the clear button with the widget"""
+        buttonSize = self.clearButton.sizeHint()
+        frameWidth = self.style().pixelMetric(
+            QtGui.QStyle.PM_DefaultFrameWidth)
+        self.clearButton.move(self.rect().right() - frameWidth -
+                              buttonSize.width(), (self.rect().bottom() -
+                              buttonSize.height() + 1)/2)
+        super(LineEditWithClearButton, self).resizeEvent(event)
+
+    def showClearButton(self):
+        """show the clear button if there's text"""
+        self.clearButton.setVisible(len(self.text()))


### PR DESCRIPTION
this adds a search field to the top of the right hand side in Preview.
If you type into this field, the buttons get filtered.

At the moment the layout is jumping and the tests are missing
