### PR TITLE
add toolbar icons (QtAwesome)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - pip install PySide --no-index --find-links https://parkin.github.io/python-wheelhouse/;
   # Travis CI servers use virtualenvs, so we need to finish the install by the following
   - python ~/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/pyside_postinstall.py -install
+  - pip install qtawesome
   - pip install coveralls
   - pip install pypandoc
   - pip install pandocfilters

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - pip install PySide --no-index --find-links https://parkin.github.io/python-wheelhouse/;
   # Travis CI servers use virtualenvs, so we need to finish the install by the following
   - python ~/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/pyside_postinstall.py -install
+  - pip install qtpy
   - pip install qtawesome
   - pip install coveralls
   - pip install pypandoc

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -164,6 +164,7 @@ class Library(CustomFrame):
         """initialize the toolbar for this view"""
         if not hasattr(self, 'toolbar'):
             self.toolbar = self.parent.addToolBar('Library')
+            self.toolbar.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
 
             # Go up in the directories (disabled if in the root directory)
             upIcon = qtawesome.icon('fa.arrow-up')
@@ -258,6 +259,7 @@ class Editing(CustomFrame):
         """initialize the toolbar for this view"""
         if not hasattr(self, 'toolbar'):
             self.toolbar = self.parent.addToolBar('Editing')
+            self.toolbar.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
             self.toolbar.setVisible(False)
 
             # save the Text in the current notebook editor
@@ -508,6 +510,7 @@ class Preview(CustomFrame):
         """initialize the toolbar for this view"""
         if not hasattr(self, 'toolbar'):
             self.toolbar = self.parent.addToolBar('Preview')
+            self.toolbar.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
             self.toolbar.setVisible(False)
 
             # Reload Action

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -18,6 +18,9 @@ from PySide import QtGui
 from PySide import QtCore
 from PySide import QtWebKit
 
+os.environ['QT_API'] = 'PySide'
+import qtawesome
+
 from .flowlayout import FlowLayout
 from .utils import fuzzySearch
 
@@ -163,25 +166,25 @@ class Library(CustomFrame):
             self.toolbar = self.parent.addToolBar('Library')
 
             # Go up in the directories (disabled if in the root directory)
-            self.upAction = QtGui.QAction(self)
-            self.upAction.setIconText('&Up')
+            upIcon = qtawesome.icon('fa.arrow-up')
+            self.upAction = QtGui.QAction(upIcon, '&Up', self)
             self.upAction.triggered.connect(self.shelves.upFolder)
             if self.info.level == self.info.root:
                 self.upAction.setDisabled(True)
             self.toolbar.addAction(self.upAction)
 
             # Create a new notebook
-            self.newNotebookAction = QtGui.QAction(self)
-            self.newNotebookAction.setIconText('&New Notebook')
-            self.newNotebookAction.setText('&New Notebook')
+            newNotebookIcon = qtawesome.icon('fa.file')
+            self.newNotebookAction = QtGui.QAction(newNotebookIcon,
+                                                   '&New Notebook', self)
             self.newNotebookAction.triggered.connect(
                 self.shelves.createNotebook)
             self.toolbar.addAction(self.newNotebookAction)
 
             # Create a new folder
-            self.newFolderAction = QtGui.QAction(self)
-            self.newFolderAction.setIconText('New Folde&r')
-            self.newFolderAction.setText('New Folde&r')
+            newFolderIcon = qtawesome.icon('fa.folder')
+            self.newFolderAction = QtGui.QAction(newFolderIcon, 'New Folde&r',
+                                                 self)
             self.newFolderAction.triggered.connect(self.shelves.createFolder)
             self.toolbar.addAction(self.newFolderAction)
 
@@ -258,14 +261,14 @@ class Editing(CustomFrame):
             self.toolbar.setVisible(False)
 
             # save the Text in the current notebook editor
-            self.saveAction = QtGui.QAction(self)
-            self.saveAction.setIconText('&Save')
+            saveIcon = qtawesome.icon('fa.floppy-o')
+            self.saveAction = QtGui.QAction(saveIcon, '&Save', self)
             self.saveAction.triggered.connect(self.saveText)
             self.toolbar.addAction(self.saveAction)
 
             # reload the Text in the current notebook editor
-            self.readAction = QtGui.QAction(self)
-            self.readAction.setIconText('&Reload')
+            readIcon = qtawesome.icon('fa.refresh')
+            self.readAction = QtGui.QAction(readIcon, '&Reload', self)
             self.readAction.triggered.connect(self.loadText)
             self.toolbar.addAction(self.readAction)
 
@@ -273,20 +276,23 @@ class Editing(CustomFrame):
             self.toolbar.addSeparator()
 
             # Create a new entry - new field in the current notebook
-            self.newEntryAction = QtGui.QAction(self)
-            self.newEntryAction.setIconText('&New entry')
+            newEntryIcon = qtawesome.icon('fa.plus-square')
+            self.newEntryAction = QtGui.QAction(newEntryIcon, '&New entry',
+                                                self)
             self.newEntryAction.triggered.connect(self.newEntry)
             self.toolbar.addAction(self.newEntryAction)
 
             # Edit in an exterior editor
-            self.editAction = QtGui.QAction(self)
-            self.editAction.setIconText('Edit (e&xterior editor)')
+            editIcon = qtawesome.icon('fa.plus-square')
+            self.editAction = QtGui.QAction(editIcon,
+                                            'Edit (e&xterior editor)', self)
             self.editAction.triggered.connect(self.editExternal)
             self.toolbar.addAction(self.editAction)
 
             # Launch the previewing of the current notebook
-            self.previewAction = QtGui.QAction(self)
-            self.previewAction.setIconText('&Preview notebook')
+            previewIcon = qtawesome.icon('fa.desktop')
+            self.previewAction = QtGui.QAction(previewIcon,
+                                               '&Preview notebook', self)
             self.previewAction.triggered.connect(self.preview)
             self.toolbar.addAction(self.previewAction)
 
@@ -505,8 +511,8 @@ class Preview(CustomFrame):
             self.toolbar.setVisible(False)
 
             # Reload Action
-            self.reloadAction = QtGui.QAction(self)
-            self.reloadAction.setIconText('&Reload')
+            reloadIcon = qtawesome.icon('fa.refresh')
+            self.reloadAction = QtGui.QAction(reloadIcon, '&Reload', self)
             self.reloadAction.triggered.connect(self.reload)
             self.toolbar.addAction(self.reloadAction)
 

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -165,6 +165,7 @@ class Library(CustomFrame):
         if not hasattr(self, 'toolbar'):
             self.toolbar = self.parent.addToolBar('Library')
             self.toolbar.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
+            self.toolbar.setIconSize(self.toolbar.iconSize() * 0.7)
 
             # Go up in the directories (disabled if in the root directory)
             upIcon = qtawesome.icon('fa.arrow-up')
@@ -260,6 +261,7 @@ class Editing(CustomFrame):
         if not hasattr(self, 'toolbar'):
             self.toolbar = self.parent.addToolBar('Editing')
             self.toolbar.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
+            self.toolbar.setIconSize(self.toolbar.iconSize() * 0.7)
             self.toolbar.setVisible(False)
 
             # save the Text in the current notebook editor
@@ -511,6 +513,7 @@ class Preview(CustomFrame):
         if not hasattr(self, 'toolbar'):
             self.toolbar = self.parent.addToolBar('Preview')
             self.toolbar.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
+            self.toolbar.setIconSize(self.toolbar.iconSize() * 0.7)
             self.toolbar.setVisible(False)
 
             # Reload Action

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -285,7 +285,7 @@ class Editing(CustomFrame):
             self.toolbar.addAction(self.newEntryAction)
 
             # Edit in an exterior editor
-            editIcon = qtawesome.icon('fa.plus-square')
+            editIcon = qtawesome.icon('fa.pencil-square-o')
             self.editAction = QtGui.QAction(editIcon,
                                             'Edit (e&xterior editor)', self)
             self.editAction.triggered.connect(self.editExternal)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(name='NoteOrganiser',
       url='https://github.com/baudren/NoteOrganiser',
       packages=PACKAGES,
       scripts=['noteorganiser/NoteOrganiser.py'],
-      install_requires=['pypandoc', 'six', 'PySide>=1.2.2', 'pygments'],
+      install_requires=['pypandoc', 'six', 'PySide>=1.2.2', 'qtawesome',
+                        'pygments'],
       data_files=ASSETS,
       )

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(name='NoteOrganiser',
       packages=PACKAGES,
       scripts=['noteorganiser/NoteOrganiser.py'],
       install_requires=['pypandoc', 'six', 'PySide>=1.2.2', 'qtawesome',
-                        'pygments'],
+                        'qtpy', 'pygments'],
       data_files=ASSETS,
       )


### PR DESCRIPTION
we use qtawesome as the icon pack.
This uses qtpy internally but we can't move to qtpy completely at the moment, because there's an issue with the QWebView. So we have to set the environment variable 'QT_API' to 'PySide' that qtawesome plays nicely together with our other QT elements
