### PR TITLE
reenable shortcuts for Toolbar items

### DIFF
--- a/noteorganiser/NoteOrganiser.py
+++ b/noteorganiser/NoteOrganiser.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 # Main imports
 import sys
 import os
+import re
 from PySide import QtGui
 from PySide import QtCore
 
@@ -242,15 +243,15 @@ class NoteOrganiser(QtGui.QMainWindow):
         # adding additional shortcuts
         self.libraryShortcut = QtGui.QAction('library', self)
         self.libraryShortcut.setShortcut('Ctrl+L')
-        self.libraryShortcut.triggered.connect(self.setActiveTabLibrary)
+        self.libraryShortcut.triggered.connect(self.setActiveTab)
         self.addAction(self.libraryShortcut)
         self.editingShortcut = QtGui.QAction('editing', self)
         self.editingShortcut.setShortcut('Ctrl+E')
-        self.editingShortcut.triggered.connect(self.setActiveTabEditing)
+        self.editingShortcut.triggered.connect(self.setActiveTab)
         self.addAction(self.editingShortcut)
-        self.previewShortcut = QtGui.QAction('library', self)
+        self.previewShortcut = QtGui.QAction('preview', self)
         self.previewShortcut.setShortcut('Ctrl+W')
-        self.previewShortcut.triggered.connect(self.setActiveTabPreview)
+        self.previewShortcut.triggered.connect(self.setActiveTab)
         self.addAction(self.previewShortcut)
 
         # Set the tabs widget to be the center widget of the main window
@@ -317,29 +318,12 @@ class NoteOrganiser(QtGui.QMainWindow):
                 getattr(self,
                         self.states[index]).toolbar.setVisible(False)
 
-    def setActiveTabLibrary(self):
+    def setActiveTab(self):
         """
-        set the active tab in the tabWidget to Library
-
-        this method is called when the custom shortcut for the tab is used
+        set the active tab in the tabWidget to the widget for which the
+        shortcut was used
         """
-        self.tabs.setCurrentWidget(self.library)
-
-    def setActiveTabEditing(self):
-        """
-        set the active tab in the tabWidget to Editing
-
-        this method is called when the custom shortcut for the tab is used
-        """
-        self.tabs.setCurrentWidget(self.editing)
-
-    def setActiveTabPreview(self):
-        """
-        set the active tab in the tabWidget to Preview
-
-        this method is called when the custom shortcut for the tab is used
-        """
-        self.tabs.setCurrentWidget(self.preview)
+        self.tabs.setCurrentWidget(getattr(self, self.sender().iconText()))
 
 
 def main(args):

--- a/noteorganiser/NoteOrganiser.py
+++ b/noteorganiser/NoteOrganiser.py
@@ -239,6 +239,20 @@ class NoteOrganiser(QtGui.QMainWindow):
         self.tabs.addTab(self.editing, "&Editing")
         self.tabs.addTab(self.preview, "Previe&w")
 
+        # adding additional shortcuts
+        self.libraryShortcut = QtGui.QAction('library', self)
+        self.libraryShortcut.setShortcut('Ctrl+L')
+        self.libraryShortcut.triggered.connect(self.setActiveTabLibrary)
+        self.addAction(self.libraryShortcut)
+        self.editingShortcut = QtGui.QAction('editing', self)
+        self.editingShortcut.setShortcut('Ctrl+E')
+        self.editingShortcut.triggered.connect(self.setActiveTabEditing)
+        self.addAction(self.editingShortcut)
+        self.previewShortcut = QtGui.QAction('library', self)
+        self.previewShortcut.setShortcut('Ctrl+W')
+        self.previewShortcut.triggered.connect(self.setActiveTabPreview)
+        self.addAction(self.previewShortcut)
+
         # Set the tabs widget to be the center widget of the main window
         self.log.info("Setting the central widget")
         self.setCentralWidget(self.tabs)
@@ -302,6 +316,30 @@ class NoteOrganiser(QtGui.QMainWindow):
             if index != tabIndex:
                 getattr(self,
                         self.states[index]).toolbar.setVisible(False)
+
+    def setActiveTabLibrary(self):
+        """
+        set the active tab in the tabWidget to Library
+
+        this method is called when the custom shortcut for the tab is used
+        """
+        self.tabs.setCurrentWidget(self.library)
+
+    def setActiveTabEditing(self):
+        """
+        set the active tab in the tabWidget to Editing
+
+        this method is called when the custom shortcut for the tab is used
+        """
+        self.tabs.setCurrentWidget(self.editing)
+
+    def setActiveTabPreview(self):
+        """
+        set the active tab in the tabWidget to Preview
+
+        this method is called when the custom shortcut for the tab is used
+        """
+        self.tabs.setCurrentWidget(self.preview)
 
 
 def main(args):

--- a/noteorganiser/NoteOrganiser.py
+++ b/noteorganiser/NoteOrganiser.py
@@ -97,7 +97,6 @@ class NoteOrganiser(QtGui.QMainWindow):
 
         # Toggle displaying empty folders
         toggleEmptyAction = QtGui.QAction('display empty folders', self)
-        toggleEmptyAction.setShortcut('Ctrl+T')
         toggleEmptyAction.setStatusTip('Toggle the display of empty folders')
         toggleEmptyAction.setCheckable(True)
         toggleEmptyAction.setChecked(self.info.display_empty)

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -192,8 +192,7 @@ class Library(CustomFrame):
             self.newFolderAction = QtGui.QAction(newFolderIcon, 'New Folde&r',
                                                  self)
             self.newFolderAction.setIconText('New Folde&r')
-            #collision: Reload
-            #self.newFolderAction.setShortcut('Ctrl+R')
+            self.newFolderAction.setShortcut('Ctrl+F')
             self.newFolderAction.triggered.connect(self.shelves.createFolder)
             self.toolbar.addAction(self.newFolderAction)
 
@@ -302,10 +301,9 @@ class Editing(CustomFrame):
             # Edit in an exterior editor
             editIcon = qtawesome.icon('fa.pencil-square-o')
             self.editAction = QtGui.QAction(editIcon,
-                                            'Edit (e&xterior editor)', self)
-            self.editAction.setIconText('Edit (e&xterior editor)')
-            # collision: Cut
-            #self.editAction.setShortcut('Ctrl+X')
+                                            'Edi&t (exterior editor)', self)
+            self.editAction.setIconText('Edi&t (exterior editor)')
+            self.editAction.setShortcut('Ctrl+T')
             self.editAction.triggered.connect(self.editExternal)
             self.toolbar.addAction(self.editAction)
 

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -494,6 +494,13 @@ class Preview(CustomFrame):
         self.searchField.setMaximumWidth(165)
         vbox.addWidget(self.searchField)
 
+        # create a shortcut to jump into the search field
+        if not hasattr(self, 'searchAction'):
+            self.searchAction = QtGui.QAction(self)
+            self.searchAction.setShortcut('Ctrl+F')
+            self.searchAction.triggered.connect(self.onSearchAction)
+            self.addAction(self.searchAction)
+
         self.tagButtons = []
         if self.extracted_tags:
             for key, value in six.iteritems(self.extracted_tags):
@@ -689,6 +696,10 @@ class Preview(CustomFrame):
 
     def resetSize(self):
         self.web.setTextSizeMultiplier(1)
+
+    def onSearchAction(self):
+        """Search shortcut was pressed. Set focus to the searchfield"""
+        self.searchField.setFocus()
 
     def reload(self):
         """

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -170,6 +170,7 @@ class Library(CustomFrame):
             # Go up in the directories (disabled if in the root directory)
             upIcon = qtawesome.icon('fa.arrow-up')
             self.upAction = QtGui.QAction(upIcon, '&Up', self)
+            self.upAction.setIconText('&Up')
             self.upAction.triggered.connect(self.shelves.upFolder)
             if self.info.level == self.info.root:
                 self.upAction.setDisabled(True)
@@ -179,6 +180,7 @@ class Library(CustomFrame):
             newNotebookIcon = qtawesome.icon('fa.file')
             self.newNotebookAction = QtGui.QAction(newNotebookIcon,
                                                    '&New Notebook', self)
+            self.newNotebookAction.setIconText('&New Notebook')
             self.newNotebookAction.triggered.connect(
                 self.shelves.createNotebook)
             self.toolbar.addAction(self.newNotebookAction)
@@ -187,6 +189,7 @@ class Library(CustomFrame):
             newFolderIcon = qtawesome.icon('fa.folder')
             self.newFolderAction = QtGui.QAction(newFolderIcon, 'New Folde&r',
                                                  self)
+            self.newFolderAction.setIconText('New Folde&r')
             self.newFolderAction.triggered.connect(self.shelves.createFolder)
             self.toolbar.addAction(self.newFolderAction)
 
@@ -267,12 +270,14 @@ class Editing(CustomFrame):
             # save the Text in the current notebook editor
             saveIcon = qtawesome.icon('fa.floppy-o')
             self.saveAction = QtGui.QAction(saveIcon, '&Save', self)
+            self.saveAction.setIconText('&Save')
             self.saveAction.triggered.connect(self.saveText)
             self.toolbar.addAction(self.saveAction)
 
             # reload the Text in the current notebook editor
             readIcon = qtawesome.icon('fa.refresh')
             self.readAction = QtGui.QAction(readIcon, '&Reload', self)
+            self.readAction.setIconText('&Reload')
             self.readAction.triggered.connect(self.loadText)
             self.toolbar.addAction(self.readAction)
 
@@ -283,6 +288,7 @@ class Editing(CustomFrame):
             newEntryIcon = qtawesome.icon('fa.plus-square')
             self.newEntryAction = QtGui.QAction(newEntryIcon, '&New entry',
                                                 self)
+            self.newEntryAction.setIconText('&New entry')
             self.newEntryAction.triggered.connect(self.newEntry)
             self.toolbar.addAction(self.newEntryAction)
 
@@ -290,6 +296,7 @@ class Editing(CustomFrame):
             editIcon = qtawesome.icon('fa.pencil-square-o')
             self.editAction = QtGui.QAction(editIcon,
                                             'Edit (e&xterior editor)', self)
+            self.editAction.setIconText('Edit (e&xterior editor)')
             self.editAction.triggered.connect(self.editExternal)
             self.toolbar.addAction(self.editAction)
 
@@ -297,6 +304,7 @@ class Editing(CustomFrame):
             previewIcon = qtawesome.icon('fa.desktop')
             self.previewAction = QtGui.QAction(previewIcon,
                                                '&Preview notebook', self)
+            self.previewAction.setIconText('&Preview notebook')
             self.previewAction.triggered.connect(self.preview)
             self.toolbar.addAction(self.previewAction)
 
@@ -519,6 +527,7 @@ class Preview(CustomFrame):
             # Reload Action
             reloadIcon = qtawesome.icon('fa.refresh')
             self.reloadAction = QtGui.QAction(reloadIcon, '&Reload', self)
+            self.reloadAction.setIconText('&Reload')
             self.reloadAction.triggered.connect(self.reload)
             self.toolbar.addAction(self.reloadAction)
 

--- a/noteorganiser/frames.py
+++ b/noteorganiser/frames.py
@@ -171,6 +171,7 @@ class Library(CustomFrame):
             upIcon = qtawesome.icon('fa.arrow-up')
             self.upAction = QtGui.QAction(upIcon, '&Up', self)
             self.upAction.setIconText('&Up')
+            self.upAction.setShortcut('Ctrl+U')
             self.upAction.triggered.connect(self.shelves.upFolder)
             if self.info.level == self.info.root:
                 self.upAction.setDisabled(True)
@@ -181,6 +182,7 @@ class Library(CustomFrame):
             self.newNotebookAction = QtGui.QAction(newNotebookIcon,
                                                    '&New Notebook', self)
             self.newNotebookAction.setIconText('&New Notebook')
+            self.newNotebookAction.setShortcut('Ctrl+N')
             self.newNotebookAction.triggered.connect(
                 self.shelves.createNotebook)
             self.toolbar.addAction(self.newNotebookAction)
@@ -190,6 +192,8 @@ class Library(CustomFrame):
             self.newFolderAction = QtGui.QAction(newFolderIcon, 'New Folde&r',
                                                  self)
             self.newFolderAction.setIconText('New Folde&r')
+            #collision: Reload
+            #self.newFolderAction.setShortcut('Ctrl+R')
             self.newFolderAction.triggered.connect(self.shelves.createFolder)
             self.toolbar.addAction(self.newFolderAction)
 
@@ -271,6 +275,7 @@ class Editing(CustomFrame):
             saveIcon = qtawesome.icon('fa.floppy-o')
             self.saveAction = QtGui.QAction(saveIcon, '&Save', self)
             self.saveAction.setIconText('&Save')
+            self.saveAction.setShortcut('Ctrl+S')
             self.saveAction.triggered.connect(self.saveText)
             self.toolbar.addAction(self.saveAction)
 
@@ -278,6 +283,7 @@ class Editing(CustomFrame):
             readIcon = qtawesome.icon('fa.refresh')
             self.readAction = QtGui.QAction(readIcon, '&Reload', self)
             self.readAction.setIconText('&Reload')
+            self.readAction.setShortcut('Ctrl+R')
             self.readAction.triggered.connect(self.loadText)
             self.toolbar.addAction(self.readAction)
 
@@ -289,6 +295,7 @@ class Editing(CustomFrame):
             self.newEntryAction = QtGui.QAction(newEntryIcon, '&New entry',
                                                 self)
             self.newEntryAction.setIconText('&New entry')
+            self.newEntryAction.setShortcut('Ctrl+N')
             self.newEntryAction.triggered.connect(self.newEntry)
             self.toolbar.addAction(self.newEntryAction)
 
@@ -297,6 +304,8 @@ class Editing(CustomFrame):
             self.editAction = QtGui.QAction(editIcon,
                                             'Edit (e&xterior editor)', self)
             self.editAction.setIconText('Edit (e&xterior editor)')
+            # collision: Cut
+            #self.editAction.setShortcut('Ctrl+X')
             self.editAction.triggered.connect(self.editExternal)
             self.toolbar.addAction(self.editAction)
 
@@ -305,6 +314,7 @@ class Editing(CustomFrame):
             self.previewAction = QtGui.QAction(previewIcon,
                                                '&Preview notebook', self)
             self.previewAction.setIconText('&Preview notebook')
+            self.previewAction.setShortcut('Ctrl+P')
             self.previewAction.triggered.connect(self.preview)
             self.toolbar.addAction(self.previewAction)
 
@@ -535,6 +545,7 @@ class Preview(CustomFrame):
             reloadIcon = qtawesome.icon('fa.refresh')
             self.reloadAction = QtGui.QAction(reloadIcon, '&Reload', self)
             self.reloadAction.setIconText('&Reload')
+            self.reloadAction.setShortcut('Ctrl+R')
             self.reloadAction.triggered.connect(self.reload)
             self.toolbar.addAction(self.reloadAction)
 


### PR DESCRIPTION
(#74)
- Fix missing shortcuts after #73
- add new shortcuts with `Ctrl`

Available shortcuts:
- Library
  - [x] Up - `Ctrl+U` (no collision)
  - [x] New Notebook - `Ctrl+N` (No collision)
  - [x] New Folder - `Ctrl+F` (Collision: **Search** _Alt+F -> Menu File_)
- Editing
  - [x] Save - `Ctrl+S` (No collision)
  - [x] Reload - `Ctrl+R` (No collision)
  - [x] New entry - `Ctrl+N` (No collision)
  - [x] Edit exterior - `Ctrl+T` (Collision: **_new tab**_)
  - [x] Preview - `Ctrl+P` (Collision: **Print?**)
- Preview
  - [x] Reload - `Ctrl+R` (No collision)
  - [x] Search Tags - `Ctrl+F` (No collision)
- Tabs
  - [x] Library - `Ctrl+L` (No collision)
  - [x] Editing - `Ctrl+E` (No collision)
  - [x] Preview - `Ctrl+W` (Collision: **Close Tab/View**)
- Zoom
  - [x] zoom in - `Ctrl++` (No collision)
  - [x] zoom out - `Ctrl+-` (No collision)
  - [x] reset zoom - `Ctrl+0` (No collision)
- other shortcuts
  - [x] File > Exit - `Ctrl+Q` (No collision)
  - [x] ( Options > Display empty folders - `Ctrl+T` (No collision) ) **REMOVED**
