### PR TITLE
underlined titles are now syntax highlighted in editor

### DIFF
--- a/noteorganiser/syntax.py
+++ b/noteorganiser/syntax.py
@@ -111,13 +111,10 @@ class ModifiedMarkdownHighlighter(QtGui.QSyntaxHighlighter):
                     index = expression.indexIn(
                         self.currentBlock().next().text())
                     if index >= 0:
-                        # Also check for the next, next line to be non-empty.
-                        # This should force it to be a title.
-                        if self.currentBlock().next().next().text():
-                            length = expression.matchedLength()
-                            self.setFormat(index, length, _format)
-                            index = expression.indexIn(text, index + length)
-                            self.setCurrentBlockState(2)
+                        length = expression.matchedLength()
+                        self.setFormat(index, length, _format)
+                        index = expression.indexIn(text, index + length)
+                        self.setCurrentBlockState(2)
             # If the title has already been highlighted, the state is '2'
             else:
                 for pattern, _format in self.underliningRules:

--- a/noteorganiser/syntax.py
+++ b/noteorganiser/syntax.py
@@ -111,10 +111,13 @@ class ModifiedMarkdownHighlighter(QtGui.QSyntaxHighlighter):
                     index = expression.indexIn(
                         self.currentBlock().next().text())
                     if index >= 0:
-                        length = expression.matchedLength()
-                        self.setFormat(index, length, _format)
-                        index = expression.indexIn(text, index + length)
-                        self.setCurrentBlockState(2)
+                        # Also check for the next, next line to be non-empty.
+                        # This should force it to be a title.
+                        if self.currentBlock().next().next().text():
+                            length = expression.matchedLength()
+                            self.setFormat(index, length, _format)
+                            index = expression.indexIn(text, index + length)
+                            self.setCurrentBlockState(2)
             # If the title has already been highlighted, the state is '2'
             else:
                 for pattern, _format in self.underliningRules:

--- a/noteorganiser/text_processing.py
+++ b/noteorganiser/text_processing.py
@@ -159,11 +159,18 @@ def extract_title_and_posts_from_text(text):
             title = ' '.join(text[:index]).strip()
             has_title = True
         if re.match('^-{2,}$', line) and line[0] == '-':
-            # find the latest non empty line
-            for backward_index in range(1, 10):
-                if not text[index-backward_index].strip():
-                    post_starting_indices.append(index-backward_index+1)
-                    break
+            # Check that the lines surrounding this line of dashes are
+            # non-empty, otherwise it could be the beginning or end of a table.
+            previous_line = text[index-1].rstrip('\n')
+            if index+1 < len(text)-1:
+                next_line = text[index+1].rstrip('\n')
+                if previous_line and next_line:
+                    # find the latest non empty line
+                    for backward_index in range(1, 10):
+                        if not text[index-backward_index].strip():
+                            post_starting_indices.append(
+                                index-backward_index+1)
+                            break
 
     if not has_title:
         raise MarkdownSyntaxError(


### PR DESCRIPTION
Fix for #67. So far, only underlined titles are considered, and nothing is done for inline ones.
